### PR TITLE
Fix output path help text

### DIFF
--- a/src/create_database.py
+++ b/src/create_database.py
@@ -128,7 +128,7 @@ def parse_args():
         "--output",
         type=Path,
         default=Path("hot_100.sqlite"),
-        help="Path to output SQLite database file (default: hot_100.db)"
+        help="Path to output SQLite database file (default: hot_100.sqlite)"
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- fix CLI help text for `--output`

## Testing
- `python3 -m py_compile src/create_database.py`


------
https://chatgpt.com/codex/tasks/task_e_683f902852cc8333ae28026a5dac3dc6