### PR TITLE
Add unit test for aggregate_song_stats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,18 @@ Links to youtube and lyrics for each song
 Created using Hot 100 data from here:
 https://github.com/mhollingshead/billboard-hot-100
 
-This is a still a work in progress so don't expect it to work out of the box yet (or at all).  
+This is a still a work in progress so don't expect it to work out of the box yet (or at all).
 
 Part of my experiment here was to practice using ChatGPT to write code that I wouldn't have been able to do myself
 (the javascript and htmx elements) so I'm sure a lot of the non-python code has room for improvement
 
-
 If you have uv installed already:
 ```commandline
 ./src/app.py
+```
+
+### Running tests
+Install the requirements and run `pytest`.
+```bash
+pytest
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=3.1.0
 gunicorn>=23.0.0
+pytest>=8.0.0

--- a/tests/test_create_database.py
+++ b/tests/test_create_database.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+import pydantic
+
+# Provide a minimal TypeAdapter for older pydantic versions
+if not hasattr(pydantic, "TypeAdapter"):
+    class DummyTypeAdapter:
+        def __init__(self, _):
+            pass
+        def validate_python(self, data):
+            return data
+    pydantic.TypeAdapter = DummyTypeAdapter
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from create_database import Chart, SongData, aggregate_song_stats
+
+
+def test_aggregate_song_stats_basic():
+    chart1 = Chart(
+        date="2024-01-08",
+        data=[
+            SongData(
+                song="Test Song",
+                artist="Artist",
+                this_week=10,
+                last_week=None,
+                peak_position=10,
+                weeks_on_chart=1,
+            )
+        ],
+    )
+    chart2 = Chart(
+        date="2024-01-01",
+        data=[
+            SongData(
+                song="Test Song",
+                artist="Artist",
+                this_week=5,
+                last_week=10,
+                peak_position=5,
+                weeks_on_chart=2,
+            )
+        ],
+    )
+
+    stats = aggregate_song_stats([chart1, chart2])
+    key = ("Test Song", "Artist")
+    assert key in stats
+    song_stat = stats[key]
+    assert song_stat.first_date == "2024-01-01"
+    assert song_stat.peak_position == 5
+    assert song_stat.weeks_on_chart == 2


### PR DESCRIPTION
## Summary
- create `tests/` with a unit test for `aggregate_song_stats`
- document how to run the test suite
- add `pytest` to requirements for running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9111465483339062eaf3365094d9